### PR TITLE
Line 180: explicit library

### DIFF
--- a/BIN-Sequence.R
+++ b/BIN-Sequence.R
@@ -177,7 +177,7 @@ toupper(tolower(s))
 
 
 # ===   6.1.2  Reverse                    
-reverse(s)
+Biostrings::reverse(s)
 
 
 # ===   6.1.3  Change characters          


### PR DESCRIPTION
Without library(Biostrings), Line 180 does not seem to work. I accidentally found out that reverse() that works come from the package Biostrings that this code depends on.